### PR TITLE
[WIP] Refactor the build_system feature to merge it into the fallback feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@ This plugin provides commands for using the build system to which the
 current file belongs. It searches from each files directory upwards for
 Makefiles and the like. These commands are provided:
 
-* **:Build** - Build/run a target
+* **:Build** - General purpose command for common tasks (build, run, clean...)
 * **:BuildInit** - Initialize/configure a build
 * **:BuildInfo** - Print build informations for the current file
+* **:BuildRefresh** - Force a fresh discovery of build system
 
 **Note**: If the current file does not belong to any known build systems,
 it will be build using associated compilers. E.g. C files will be build
@@ -33,10 +34,11 @@ The `:Build` command runs `make` inside the build directory. It takes
 optional arguments which will be passed directly to `make`:
 
 ```vim
-:Build
-:Build all
-:Build test
-:Build clean
+:Build " equivalent to :Build build
+:Build build all " build the make target all
+:Build build test " build the make target test
+:Build clean " clean the directory
+:Build run " run the current file or the whole project depending on the build system
 ```
 
 ### CMake with subdirectories
@@ -93,16 +95,14 @@ Then run `make` using the `:Build` command:
 
 ```vim
 :Build
-:Build test
 :Build clean
-:Build -j8 --keep-going --dry-run
+:Build build -j8 --keep-going --dry-run
 ```
 
 ## Plain C files
 
 If the current file does not belong to a build system, it can be compiled
-using the `:Build` command. This plugin defines three build targets for C
-files:
+using the `:Build` command. This plugin defines three subcommands for C files:
 
 ```vim
 :Build build
@@ -122,6 +122,13 @@ Pass custom arguments to the compiler:
 
 For some files which don't belong to a build system, the `run` target will
 be defined:
+It relies on the capacity of the system to directly run those files directly, which imply that you should define a shebang at the begining of the
+file.
+
+For example for python
+```python
+#!/usr/bin/env python3
+```
 
 ```vim
 :Build run

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ The `:Build` command runs `make` inside the build directory. It takes
 optional arguments which will be passed directly to `make`:
 
 ```vim
-:Build " equivalent to :Build build
-:Build build all " build the make target all
-:Build build test " build the make target test
+:Build " equivalent to :Build build, build the default target
+:Build build all " build the all target
+:Build test " run the tests
 :Build clean " clean the directory
 :Build run " run the current file or the whole project depending on the build system
 ```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ optional arguments which will be passed directly to `make`:
 :Build " equivalent to :Build build, build the default target
 :Build build all
 :Build test " run the tests
-:Build clea
+:Build clean
 :Build run " run the current file or the whole project depending on the build system
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 This plugin provides commands for using the build system to which the
 current file belongs. It searches from each files directory upwards for
-Makefiles and the like. These commands are provided:
-
-* **:Build** - General purpose command for common tasks (build, run, clean...)
-* **:BuildInit** - Initialize/configure a build
-* **:BuildInfo** - Print build informations for the current file
-* **:BuildRefresh** - Force a fresh discovery of build system
+Makefiles and the like.
+A general purpose **:Build** command cover for common tasks (build, run, clean...).
 
 **Note**: If the current file does not belong to any known build systems,
 it will be build using associated compilers. E.g. C files will be build
@@ -27,7 +23,7 @@ Open any file in the project and use the following command to initialize
 CMake. Optional arguments can be provided:
 
 ```vim
-:BuildInit -DCMAKE_BUILD_TYPE=Release
+:Build init -DCMAKE_BUILD_TYPE=Release
 ```
 
 The `:Build` command runs `make` inside the build directory. It takes
@@ -35,9 +31,9 @@ optional arguments which will be passed directly to `make`:
 
 ```vim
 :Build " equivalent to :Build build, build the default target
-:Build build all " build the all target
+:Build build all
 :Build test " run the tests
-:Build clean " clean the directory
+:Build clea
 :Build run " run the current file or the whole project depending on the build system
 ```
 
@@ -62,7 +58,7 @@ as in the previous example:
 
 ```vim
 :lchdir ~/path/to/project
-:BuildInit -DCMAKE_BUILD_TYPE=Release
+:Build init -DCMAKE_BUILD_TYPE=Release
 :Build
 ```
 
@@ -88,7 +84,7 @@ Open any file in the project and configure the build using the following
 command. Optional configure flags can be provided:
 
 ```vim
-:BuildInit --enable-gtk --without-foo --prefix="$HOME/.local"
+:Build init --enable-gtk --without-foo --prefix="$HOME/.local"
 ```
 
 Then run `make` using the `:Build` command:
@@ -122,14 +118,15 @@ Pass custom arguments to the compiler:
 
 For some files which don't belong to a build system, the `run` target will
 be defined:
-It relies on the capacity of the system to directly run those files directly, which imply that you should define a shebang at the begining of the
+
+```vim
+:Build run
+```
+
+It relies on the capacity of the system to directly run those files directly, which implies that you should define a shebang at the begining of the
 file.
 
 For example for python
 ```python
 #!/usr/bin/env python3
-```
-
-```vim
-:Build run
 ```

--- a/autoload/build.vim
+++ b/autoload/build.vim
@@ -457,6 +457,33 @@ function! s:print_command_examples(commands, build_system) " {{{
   endfor
 endfunction " }}}
 
+" Print an info message for the given build system
+function! s:info_message(build_system)
+  let l:commands = s:gather_commands(a:build_system)
+
+  if a:build_system.fallback
+    call s:log('Current file does not belong to any known build system')
+    if empty(l:commands)
+      echo 'No fallback commands defined for filetype "' . &filetype . '".'
+      return
+    endif
+    echo 'Fallback commands are provided. See the examples below.'
+  else
+    echo 'Build system:      ' . a:build_system.name
+    echo 'Project directory: ' . a:build_system.path
+  endif
+endfunction
+
+" Print a help message for the given build system
+function! s:help_message(build_system)
+  let l:commands = s:gather_commands(a:build_system)
+  echo 'Usage:'
+  echo '  :Build [SUBCMD [args...]]'
+  echo "\n"
+  echo 'Examples:'
+  call s:print_command_examples(l:commands, a:build_system)
+endfunction
+
 " Run the provided subcommand. If no argument is provided, the default
 " subcommand is build.  Arguments must be supplied as a single string.
 " '[SUBCMD [args...]]', e.g. 'clean' or 'clean --all'.
@@ -502,6 +529,14 @@ function! build#target(...) " {{{
     let l:extra_args = l:split_args[2]
   endif
 
+  if l:subcmd ==# 'init'
+    return build#init(l:extra_args)
+  elseif l:subcmd ==# 'help'
+    return s:help_message(l:build_system)
+  elseif l:subcmd ==# 'info'
+    return s:info_message(l:build_system)
+  endif
+
   let l:commands = s:gather_commands(l:build_system)
   if empty(l:commands)
     if l:build_system.fallback
@@ -523,8 +558,7 @@ function! build#target(...) " {{{
         \ . l:build_system.name . '"')
     endif
     echo "\n"
-    echo 'Commands available for this file:'
-    call s:print_command_examples(l:commands, l:build_system)
+    call s:help_message(l:build_system)
     return
   endif
 
@@ -534,23 +568,7 @@ endfunction " }}}
 " Print build informations about the current file.
 function! build#info() " {{{
   let l:build_system = build#get_current_build_system()
-  let l:commands = s:gather_commands(l:build_system)
-
-  if l:build_system.fallback
-    echo 'No fallback commands defined for filetype "' . &filetype . '".'
-    if empty(l:commands)
-      return
-    endif
-    echo 'Fallback commands are provided. See the examples below.'
-  else
-    echo 'Build system:      ' . l:build_system.name
-    echo 'Project directory: ' . l:build_system.path
-  endif
-
+  call s:info_message(l:build_system)
   echo "\n"
-  echo 'Usage:'
-  echo '  :Build [SUBCMD [args...]]'
-  echo "\n"
-  echo 'Examples:'
-  call s:print_command_examples(l:commands, l:build_system)
+  call s:help_message(l:build_system)
 endfunction " }}}

--- a/autoload/build.vim
+++ b/autoload/build.vim
@@ -522,10 +522,8 @@ function! build#target(...) " {{{
     let l:extra_args = l:split_args[2]
   endif
 
-  if l:subcmd ==# 'help'
-    return s:help_message(l:build_system)
-  elseif l:subcmd ==# 'info'
-    return s:info_message(l:build_system)
+  if l:subcmd ==# 'info'
+    return build#info()
   endif
 
   let l:commands = s:gather_commands(l:build_system)

--- a/autoload/build.vim
+++ b/autoload/build.vim
@@ -19,6 +19,7 @@ let s:build_systems =
   \        'clean' : 'make --jobs=' . s:jobs . ' clean',
   \        'init'  : './configure',
   \        'run'   : './%RELPATH%/%HEAD%',
+  \        'test' : 'make --jobs=' . s:jobs . ' test',
   \     }
   \   },
   \   'Cargo':
@@ -30,6 +31,7 @@ let s:build_systems =
   \        'build' : 'cargo build',
   \        'clean' : 'cargo clean',
   \        'run'   : 'cargo run',
+  \        'test'  : 'cargo test',
   \     },
   \   },
   \   'CMake':
@@ -45,6 +47,7 @@ let s:build_systems =
   \                . ' && cd build/'
   \                . ' && cmake ../ -DCMAKE_EXPORT_COMPILE_COMMANDS=1',
   \        'run'   : './build/%HEAD%',
+  \        'test' : 'cmake --build ./build/ -- -j ' . s:jobs . ' test',
   \     },
   \   },
   \   'DUB':
@@ -56,6 +59,7 @@ let s:build_systems =
   \        'build' : 'dub build',
   \        'clean' : 'dub clean',
   \        'run'   : 'dub run',
+  \        'test'  : 'dub test',
   \     },
   \   },
   \   'Dune':
@@ -67,6 +71,7 @@ let s:build_systems =
   \       'build'  : 'dune build',
   \       'clean'  : 'dune clean',
   \       'run'    : 'dune exec ./%RELPATH%/%HEAD%.exe',
+  \       'test'   : 'dune runtest',
   \     },
   \   },
   \   'Make':
@@ -78,6 +83,7 @@ let s:build_systems =
   \        'build' : 'make --jobs=' . s:jobs,
   \        'clean' : 'make --jobs=' . s:jobs . ' clean',
   \        'run'   : './%RELPATH%/%HEAD%',
+  \        'test'  : 'make --jobs=' . s:jobs . ' test',
   \     }
   \   },
   \   'Maven':
@@ -88,6 +94,7 @@ let s:build_systems =
   \        'do'    : 'mvn',
   \        'build' : 'mvn build',
   \        'clean' : 'mvn clean',
+  \        'test'  : 'mvn test',
   \     }
   \   },
   \ }

--- a/autoload/build.vim
+++ b/autoload/build.vim
@@ -4,8 +4,6 @@ else
   let s:jobs = 1
 endif
 
-let s:current_build_system = {}
-
 " Informations about various builds systems. {{{
 let s:build_systems =
   \ {
@@ -380,8 +378,7 @@ endfunction " }}}
 " system. If no build system could be found, a fallback build system
 " based on file type is proposed
 " The result is stored on the first call and the research will not be done
-" again. To force the research to be refreshed, provide v:true as an optional
-" argument.
+" again.
 "
 " Example: When run in a buffer containing /some/path/CMakeLists.txt
 "   build#get_current_build_system()
@@ -391,11 +388,7 @@ endfunction " }}}
 "   'path': '/some/path',
 "   'fallback': v:false,
 " }
-function! build#get_current_build_system(...) " {{{
-  if !empty(s:current_build_system) && (a:0 == 0 || !a:1)
-    return s:current_build_system
-  end
-
+function! build#get_current_build_system() " {{{
   let l:current_path = expand('%:p')
   if !strlen(l:current_path)
     let s:current_build_system = {'name': &filetype, 'fallback': v:true, 'path': '.'}

--- a/autoload/build.vim
+++ b/autoload/build.vim
@@ -265,8 +265,7 @@ function! s:gather_commands(build_system) " {{{
       call extend(l:commands, g:build#languages[l:name])
     endif
   else
-    if has_key(s:build_systems, l:name)
-      \ && has_key(s:build_systems[l:name], 'commands')
+    if has_key(s:build_systems, l:name) && has_key(s:build_systems[l:name], 'commands')
       let l:commands = copy(s:build_systems[l:name].commands)
     endif
     if exists('g:build#systems')
@@ -307,12 +306,9 @@ endfunction " }}}
 "   "This is 'main.cpp'"
 function! s:prepare_cmd_for_shell(str, build_system) " {{{
   let l:str = a:str
-  let l:str = substitute(l:str, '%PATH%',
-        \ escape(shellescape(expand('%:p:h')), '\'), 'g')
-  let l:str = substitute(l:str, '%NAME%',
-        \ escape(shellescape(expand('%:t')), '\'),   'g')
-  let l:str = substitute(l:str, '%HEAD%',
-        \ escape(shellescape(expand('%:t:r')), '\'), 'g')
+  let l:str = substitute(l:str, '%PATH%', escape(shellescape(expand('%:p:h')), '\'), 'g')
+  let l:str = substitute(l:str, '%NAME%', escape(shellescape(expand('%:t')), '\'),   'g')
+  let l:str = substitute(l:str, '%HEAD%', escape(shellescape(expand('%:t:r')), '\'), 'g')
   if a:build_system.fallback
     let l:str = substitute(l:str, '%RELPATH%', '.', 'g')
   else
@@ -371,8 +367,7 @@ endfunction " }}}
 function! s:get_first_build_system_in_dir(dir, build_system_names) " {{{
   for l:build_name in a:build_system_names
     for l:build_file in split(s:get_buildsys_item(l:build_name, 'file'), ',')
-      if filereadable(a:dir . '/' . l:build_file)
-            \ || !empty(glob(a:dir . '/' . l:build_file))
+      if filereadable(a:dir . '/' . l:build_file) || !empty(glob(a:dir . '/' . l:build_file))
         return l:build_name
       endif
     endfor
@@ -561,8 +556,7 @@ function! build#target(...) " {{{
   if !has_key(l:commands, l:subcmd)
     if l:build_system.fallback
       call s:log('Current file does not belong to any known build system')
-      call s:log('Command "' . l:subcmd . '" is not defined for the filetype "'
-        \ . &filetype . '"')
+      call s:log('Command "' . l:subcmd . '" is not defined for the filetype "' . &filetype . '"')
     else
       call s:log('Command "' . l:subcmd . '" is not defined for the build system "'
         \ . l:build_system.name . '"')

--- a/autoload/build.vim
+++ b/autoload/build.vim
@@ -39,7 +39,7 @@ let s:build_systems =
   \     {
   \        'do'    : 'cmake --build ./build/ -- -j ' . s:jobs,
   \        'build' : 'cmake --build ./build/ -- -j ' . s:jobs,
-  \        'clean' : 'rm -r build',
+  \        'clean' : 'cmake --build ./build/ -- clean',
   \        'init'  : 'ln -sf build/compile_commands.json'
   \                . ' && mkdir -p build/'
   \                . ' && cd build/'

--- a/autoload/build.vim
+++ b/autoload/build.vim
@@ -4,6 +4,8 @@ else
   let s:jobs = 1
 endif
 
+let s:current_build_system = {}
+
 " Informations about various builds systems. {{{
 let s:build_systems =
   \ {
@@ -375,18 +377,27 @@ endfunction " }}}
 " Returns a dictionary containing informations about the current build
 " system. If no build system could be found, a fallback build system
 " based on file type is proposed
+" The result is stored on the first call and the research will not be done
+" again. To force the research to be refreshed, provide v:true as an optional
+" argument.
 "
 " Example: When run in a buffer containing /some/path/CMakeLists.txt
+"   build#get_current_build_system()
 " Result:
 " {
 "   'name': 'CMake',
 "   'path': '/some/path',
 "   'fallback': v:false,
 " }
-function! build#get_current_build_system() " {{{
+function! build#get_current_build_system(...) " {{{
+  if !empty(s:current_build_system) && (a:0 == 0 || !a:1)
+    return s:current_build_system
+  end
+
   let l:current_path = expand('%:p')
   if !strlen(l:current_path)
-    return {'name': &filetype, 'fallback': v:true, 'path': '.'}
+    let s:current_build_system = {'name': &filetype, 'fallback': v:true, 'path': '.'}
+    return s:current_build_system
   endif
 
   let l:known_systems = s:get_list_of_known_build_system_names()
@@ -396,11 +407,12 @@ function! build#get_current_build_system() " {{{
   if stridx(l:current_path, getcwd()) == 0
     let l:build_system_name = s:get_first_build_system_in_dir(getcwd(), l:known_systems)
     if !empty(l:build_system_name)
-      return {
+      let s:current_build_system = {
         \ 'name': l:build_system_name,
         \ 'path': getcwd(),
         \ 'fallback': v:false,
         \ }
+      return s:current_build_system
     endif
   endif
 
@@ -410,14 +422,16 @@ function! build#get_current_build_system() " {{{
     let l:current_path = fnamemodify(l:current_path, ':h')
     let l:build_system_name = s:get_first_build_system_in_dir(l:current_path, l:known_systems)
     if !empty(l:build_system_name)
-      return {
+      let s:current_build_system = {
         \ 'name': l:build_system_name,
         \ 'path': l:current_path,
         \ 'fallback': v:false,
         \ }
+      return s:current_build_system
     endif
   endwhile
-  return {'name': &filetype, 'fallback': v:true, 'path': '.'}
+  let s:current_build_system = {'name': &filetype, 'fallback': v:true, 'path': '.'}
+  return s:current_build_system
 endfunction " }}}
 
 " Try to initialize the init system to which the current file belongs. Takes one optional string

--- a/autoload/build.vim
+++ b/autoload/build.vim
@@ -195,10 +195,10 @@ endfunction " }}}
 " if dest or start are relative path, they are taken
 " relative to the current working directory
 " Example:
-"   " current working directory is /a/b/c
-"   s:relative_to('/a/b/d/e/f/g', '../d/e')
+"   " current working directory is /common_root/work_dir
+"   s:relative_to('/common_root/build_dir/path/to/file', '../build_dir/path')
 " Returns:
-"   'f/g'
+"   'to/file'
 function! s:relative_to(dest, start) " {{{
   " make sure both path are absolute
   let l:dest = fnamemodify(a:dest, ':p')

--- a/autoload/build.vim
+++ b/autoload/build.vim
@@ -44,7 +44,7 @@ let s:build_systems =
   \                . ' && mkdir -p build/'
   \                . ' && cd build/'
   \                . ' && cmake ../ -DCMAKE_EXPORT_COMPILE_COMMANDS=1',
-  \        'run'   : './build/%HEAD%',
+  \        'run'   : 'cmake --build ./build/ -- run',
   \        'test' : 'cmake --build ./build/ -- -j ' . s:jobs . ' test',
   \     },
   \   },

--- a/autoload/build.vim
+++ b/autoload/build.vim
@@ -364,7 +364,7 @@ endfunction " }}}
 function! s:get_first_build_system_in_dir(dir, build_system_names) " {{{
   for l:build_name in a:build_system_names
     for l:build_file in split(s:get_buildsys_item(l:build_name, 'file'), ',')
-      if filereadable(a:dir . '/' . l:build_file) || !empty(glob(a:dir . '/' . l:build_file))
+      if filereadable(a:dir . '/' . l:build_file)
         return l:build_name
       endif
     endfor

--- a/doc/build.txt
+++ b/doc/build.txt
@@ -165,7 +165,7 @@ New build systems can be added to |g:build#systems|:
   \       'init' : 'mkdir .foomake_cache',
   \       'build': 'foomake build',
   \       'clean': 'foomake wipe',
-  \       'run'  : 'foomake cmd',
+  \       'run'  : 'foomake cmd ./%HEAD%',
   \       'bar'  : 'foomake bar', " an uncommon command
   \     },
   \   },

--- a/doc/build.txt
+++ b/doc/build.txt
@@ -58,6 +58,7 @@ Common subcommands are:
 - `build` tries to build the project                                  *Build_build*
 - `run` run the current file if it make sense in the current build      *Build_run*
   system, otherwise run the whole project.
+- `test` tries to run the tests                                         *Build_run*
 - `clean` cleans build artifacts                                      *Build_clean*
 - `do` is an escape hatch to access the underlying build system.         *Build_do*
   Arguments passed to `do` are passed as-is to the underlying build system
@@ -71,7 +72,7 @@ Examples:
     1) :Build
     2) :Build build --release
     3) :Build clean
-    4) :Build do runtest
+    4) :Build test
 <
 
 If the detected build system was `Make`, those commands would result in:
@@ -79,7 +80,7 @@ If the detected build system was `Make`, those commands would result in:
     1) make --jobs=4
     2) make --jobs=4 --release
     3) make --jobs=4 clean
-    4) make --jobs=4 runtest
+    4) make --jobs=4 test
 <
 
 If the detected build system was `Dune`, those would result in:
@@ -171,15 +172,17 @@ New build systems can be added to |g:build#systems|:
   \   },
   \ }
 <
+
 Every build system must have a name, a file entry and a commands entry.  The
 file entry contains a comma-separated list of filenames or globs (see vim help
 for |glob()|), describing the build files to search for. The commands entry
 contains the commands for running the build system. It will be run in the
 directory containing the build file.
 You never have to add `info` or `help` that are handled internally.
-You should provide `init` if it makes sens for your build system.
+You should provide `init` if it makes sense for your build system.
 You can add new commands if you want, they will be recognized on a per-build
 system basis.
+You can omit some of the common commands if they don't make sense in your case.
 
 Every command will be executed in the directory of the detected build file and can contain
 four different placeholders:

--- a/doc/build.txt
+++ b/doc/build.txt
@@ -156,7 +156,7 @@ You can omit some of the common commands if they don't make sense in your case.
 Every command will be executed in the directory of the detected build file and can contain
 four different placeholders:
 
-                                                                   *placeholders*
+                                                             *build_placeholders*
                                                                    *build_%PATH%*
 %PATH% - Shell-escaped absolute path to the directory containing the current
 file.

--- a/doc/build.txt
+++ b/doc/build.txt
@@ -156,6 +156,7 @@ You can omit some of the common commands if they don't make sense in your case.
 Every command will be executed in the directory of the detected build file and can contain
 four different placeholders:
 
+                                                                   *placeholders*
                                                                    *build_%PATH%*
 %PATH% - Shell-escaped absolute path to the directory containing the current
 file.
@@ -184,7 +185,7 @@ create a dictionary named |g:build#languages|. Here is an example:
     \ }
 <
 Every command will be executed in the directory of the current file and can
-contain the same placeholders. In this case %RELPATH% always expand to `'.'`.
+contain the same |placeholders|. In this case %RELPATH% always expand to `'.'`.
 
 ===============================================================================
 5. License                                                        *build-license*

--- a/doc/build.txt
+++ b/doc/build.txt
@@ -25,12 +25,6 @@ the underlying build system (or its absence).
 2. Commands                                                      *build-commands*
                                                                           *Build*
 
-This plugin propose few commands:
-- `:Build` a general purpose command used to achieve common tasks
-- `:BuildInit` initialize the build system if needed
-- `:BuildInfo` provide informations and help message on the current build
-  system
-
 The `:Build` command takes either no arguments or a first argument called a
 subcommand and any number of other arguments as you would pass them to a shell
 command.
@@ -40,7 +34,7 @@ independently from how each works.
 
 For example `:Build clean` on a `Make` based project would expand to 
 `make clean` while for a `CMake` based project it would result in
-`rm -r build/`
+`cmake --build ./build -- clean`
 
 Common subcommands are:
 - `help` lists available subcommands, providing exemples of resulting  *Build_help*
@@ -142,11 +136,10 @@ New build systems can be added to |g:build#systems|:
   \ }
 <
 
-Every build system must have a name, a file entry and a commands entry.  The
-file entry contains a comma-separated list of filenames or globs (see vim help
-for |glob()|), describing the build files to search for. The commands entry
-contains the commands for running the build system. It will be run in the
-directory containing the build file.
+Every build system must have a name, a file entry and a commands entry. The file entry contains a
+comma-separated list of filenames, describing the build files to search for. The commands entry
+contains the commands for running the build system. It will be run in the directory containing the
+build file.
 You never have to add `info` or `help` that are handled internally.
 You should provide `init` if it makes sense for your build system.
 You can add new commands if you want, they will be recognized on a per-build

--- a/doc/build.txt
+++ b/doc/build.txt
@@ -32,7 +32,6 @@ This plugin propose few commands:
 - `:BuildInit` initialize the build system if needed
 - `:BuildInfo` provide informations and help message on the current build
   system
-- `:BuildRefresh` force a fresh detection of the build system
 
 -------------------------------------------------------------------------------
 2.1 Common tasks                                                          *Build*

--- a/doc/build.txt
+++ b/doc/build.txt
@@ -4,9 +4,6 @@ CONTENTS                                                         *build-contents
 
   1. Description..............................................|build-description|
   2. Commands....................................................|build-commands|
-    2.1 Common tasks......................................................|Build|
-    2.2 Initialize the current project................................|BuildInit|
-    2.3 Print build informations for the current file.................|BuildInfo|
   3. Functions..................................................|build-functions|
     3.1 Get current build system...............|build#get_current_build_system()|
   4. Options......................................................|build-options|
@@ -26,15 +23,13 @@ the underlying build system (or its absence).
 
 ===============================================================================
 2. Commands                                                      *build-commands*
+                                                                          *Build*
 
 This plugin propose few commands:
 - `:Build` a general purpose command used to achieve common tasks
 - `:BuildInit` initialize the build system if needed
 - `:BuildInfo` provide informations and help message on the current build
   system
-
--------------------------------------------------------------------------------
-2.1 Common tasks                                                          *Build*
 
 The `:Build` command takes either no arguments or a first argument called a
 subcommand and any number of other arguments as you would pass them to a shell
@@ -89,31 +84,6 @@ If the detected build system was `Dune`, those would result in:
    3) dune clean
    4) dune runtest
 <
-
--------------------------------------------------------------------------------
-2.2 Initialize the current project                                    *BuildInit*
-
-`:BuildInit` does the same thing as `:Build init`.
-It try to initialize the init system to which the current file belongs. Takes
-optional arguments which will be passed to the build systems init command.
-
-Examples:
->
-  1) :BuildInit
-  2) :BuildInit --enable-gtk --cflags="-O2 -Wall"
-<
-If the current file belongs to an autotools project, it will run the following
-commands:
->
-  1) ./configure
-  2) ./configure --enable-gtk --cflags="-O2 -Wall"
-<
--------------------------------------------------------------------------------
-2.3 Print build informations for the current file                     *BuildInfo*
-
-Show build commands and other informations related to building the current
-file.
-In effect do the same as `:Build info` and `:Build help`.
 
 ===============================================================================
 3. Functions                                                    *build-functions*

--- a/doc/build.txt
+++ b/doc/build.txt
@@ -186,15 +186,15 @@ You can omit some of the common commands if they don't make sense in your case.
 Every command will be executed in the directory of the detected build file and can contain
 four different placeholders:
 
-                                                                         *%PATH%*
+                                                                   *build_%PATH%*
 %PATH% - Shell-escaped absolute path to the directory containing the current
 file.
-                                                                      *%RELPATH%*
+                                                                *build_%RELPATH%*
 %RELPATH% - Shell-escaped relative path from the directory of the build file
 to the directory of the current file
-                                                                         *%NAME%*
+                                                                   *build_%NAME%*
 %NAME% - Shell-escaped filename with its extension.
-                                                                         *%HEAD%*
+                                                                   *build_%HEAD%*
 %HEAD% - Shell-escaped filename without its extension.
 
 -------------------------------------------------------------------------------

--- a/doc/build.txt
+++ b/doc/build.txt
@@ -4,7 +4,7 @@ CONTENTS                                                         *build-contents
 
   1. Description..............................................|build-description|
   2. Commands....................................................|build-commands|
-    2.1 Build a specific target...........................................|Build|
+    2.1 Common tasks......................................................|Build|
     2.2 Initialize the current project................................|BuildInit|
     2.3 Print build informations for the current file.................|BuildInfo|
   3. Functions..................................................|build-functions|
@@ -21,47 +21,80 @@ CONTENTS                                                         *build-contents
 belongs to a project with a build system or not. Thus it knows how to build
 and run it. This plugin works by searching from the files directory upwards,
 until it finds a known build file.
+It tries to provide a homogeneous interface for common tasks, independently of
+the underlying build system (or its absence).
 
 ===============================================================================
 2. Commands                                                      *build-commands*
 
--------------------------------------------------------------------------------
-2.1 Build a specific target                                               *Build*
+This plugin propose few commands:
+- `:Build` a general purpose command used to achieve common tasks
+- `:BuildInit` initialize the build system if needed
+- `:BuildInfo` provide informations and help message on the current build
+  system
+- `:BuildRefresh` force a fresh detection of the build system
 
-Try to build the given optional target with the specified optional arguments.
-If the current file does not belong to a build system, it will be build using
-associated compilers.
+-------------------------------------------------------------------------------
+2.1 Common tasks                                                          *Build*
+
+The `:Build` command takes either no arguments or a first argument called a
+subcommand and any number of other arguments as you would pass them to a shell
+command.
+
+Subcommands should represent the same action across different build systems
+independently from how each works.
+
+For example `:Build clean` on a `Make` based project would expand to 
+`make clean` while for a `CMake` based project it would result in
+`rm -r build/`
+
+Common subcommands are:
+- `help` lists available subcommands, providing exemples of resulting  *Build_help*
+  commands
+- `info` echoes the basic informations on the detected build system:   *Build_info*
+  working path and name
+- `init` may not be available. When it is, it initialize the build of  *Build_init*
+  the project.
+- `build` tries to build the project                                  *Build_build*
+- `run` run the current file if it make sense in the current build      *Build_run*
+  system, otherwise run the whole project.
+- `clean` cleans build artifacts                                      *Build_clean*
+- `do` is an escape hatch to access the underlying build system.         *Build_do*
+  Arguments passed to `do` are passed as-is to the underlying build system
+  command
+
+When arguments are passed to a subcommand they are passed as-is to the
+underlying build system allowing for per-project tweakings.
 
 Examples:
 >
-  1) :Build
-  2) :Build build
-  3) :Build build -O2 -DMY_MACRO="Value 123"
-  4) :Build all CFLAGS="-O2 -Werror"
-  5) :Build clean
+    1) :Build
+    2) :Build build --release
+    3) :Build clean
+    4) :Build do runtest
 <
-If the current file belongs to an autotools project, it will run the following
-commands:
+
+If the detected build system was `Make`, those commands would result in:
 >
-  1) make --jobs=8
-  2) make --jobs=8 build
-  3) make --jobs=8 build -O2 -DMY_MACRO="Value 123"
-  4) make --jobs=8 all CFLAGS="-O2 -Werror"
-  5) make --jobs=8 clean
+    1) make --jobs=4
+    2) make --jobs=4 --release
+    3) make --jobs=4 clean
+    4) make --jobs=4 runtest
 <
-If the current file is a standalone C file which does not belong to any known
-build system, it will run the following commands:
+
+If the detected build system was `Dune`, those would result in:
 >
-  1) gcc -std=c11 -Wall -Wextra ./'foo.c' -o ./'foo'
-  2) gcc -std=c11 -Wall -Wextra ./'foo.c' -o ./'foo'
-  3) gcc -std=c11 -Wall -Wextra ./'foo.c' -o ./'foo' -O2 -DMY_MACRO="Value 123"
-  4) -- ERROR: target 'all' is not defined for C files --
-  5) rm ./'foo'
+   1) dune build
+   2) dune build --release
+   3) dune clean
+   4) dune runtest
 <
+
 -------------------------------------------------------------------------------
 2.2 Initialize the current project                                    *BuildInit*
 
-Try to initialize the init system to which the current file belongs. Takes
+`:BuildInit` does the same thing as `:Build init`.
+It try to initialize the init system to which the current file belongs. Takes
 optional arguments which will be passed to the build systems init command.
 
 Examples:
@@ -80,6 +113,7 @@ commands:
 
 Show build commands and other informations related to building the current
 file.
+In effect do the same as `:Build info` and `:Build help`.
 
 ===============================================================================
 3. Functions                                                    *build-functions*
@@ -112,7 +146,10 @@ behavior, override the desired entry in |g:build#systems|:
   \ {
   \   'Make':
   \   {
-  \     'command': 'make -j20',
+  \     'commands': {
+  \       'build': 'make -j20',
+  \       'run'  : 'make run_main',
+  \     }
   \   },
   \ }
 <
@@ -122,18 +159,41 @@ New build systems can be added to |g:build#systems|:
   \ {
   \   'my-build-system':
   \   {
-  \     'file'    : 'foo.json',
-  \     'command' : 'foomake',
-  \     'init'    : './configure',
+  \     'file'     : 'foo.json',
+  \     'commands' : { 
+  \       'do'   : 'foomake',
+  \       'init' : 'mkdir .foomake_cache',
+  \       'build': 'foomake build',
+  \       'clean': 'foomake wipe',
+  \       'run'  : 'foomake cmd',
+  \       'bar'  : 'foomake bar', " an uncommon command
+  \     },
   \   },
   \ }
 <
-Every build system must have a name, a file entry and a command entry.
-The file entry contains a comma-separated list of filenames, describing the
-build files to search for. The command entry contains the command for
-running the build system. It will be run in the directory containing the
-build file. The init entry is optional and contains the command for
-initializing the build.
+Every build system must have a name, a file entry and a commands entry.  The
+file entry contains a comma-separated list of filenames or globs (see vim help
+for |glob()|), describing the build files to search for. The commands entry
+contains the commands for running the build system. It will be run in the
+directory containing the build file.
+You never have to add `info` or `help` that are handled internally.
+You should provide `init` if it makes sens for your build system.
+You can add new commands if you want, they will be recognized on a per-build
+system basis.
+
+Every command will be executed in the directory of the detected build file and can contain
+four different placeholders:
+
+                                                                         *%PATH%*
+%PATH% - Shell-escaped absolute path to the directory containing the current
+file.
+                                                                      *%RELPATH%*
+%RELPATH% - Shell-escaped relative path from the directory of the build file
+to the directory of the current file
+                                                                         *%NAME%*
+%NAME% - Shell-escaped filename with its extension.
+                                                                         *%HEAD%*
+%HEAD% - Shell-escaped filename without its extension.
 
 -------------------------------------------------------------------------------
 4.2 Define single file build commands                         *g:build#languages*
@@ -151,12 +211,8 @@ create a dictionary named |g:build#languages|. Here is an example:
     \   }
     \ }
 <
-Every command will be executed in the directory of the file and can contain
-three different placeholders:
-
-%PATH% - Shell-escaped absolute path to the directory containing the file.
-%NAME% - Shell-escaped filename with its extension.
-%HEAD% - Shell-escaped filename without its extension.
+Every command will be executed in the directory of the current file and can
+contain the same placeholders. In this case %RELPATH% always expand to `'.'`.
 
 ===============================================================================
 5. License                                                        *build-license*

--- a/plugin/build.vim
+++ b/plugin/build.vim
@@ -6,4 +6,3 @@ let g:loaded_build = 1
 command! -nargs=? -complete=file Build call build#target(<f-args>)
 command! -nargs=? -complete=file BuildInit call build#init(<f-args>)
 command! BuildInfo call build#info()
-command! BuildRefresh call build#get_current_build_system(v:true)

--- a/plugin/build.vim
+++ b/plugin/build.vim
@@ -6,3 +6,4 @@ let g:loaded_build = 1
 command! -nargs=? -complete=file Build call build#target(<f-args>)
 command! -nargs=? -complete=file BuildInit call build#init(<f-args>)
 command! BuildInfo call build#info()
+command! BuildRefresh call build#get_current_build_system(v:true)


### PR DESCRIPTION
This pull request provide an implementation of the ideas discussed in #2.
For short, it aims at providing a homogeneous interface for simplest tasks regardless of the build system.
The interface is mirrored from the existing interface of the fallback system where default targets were defined depending on the filetype.
In effect this PR use the existing fallback code to implement the build system code.

To make clear that targets may be something else that a build target, they are renamed subcommands.

TODO:
- [x] refactor to use only subcommands and not prefix + target
- [x] allow for user customization
- [x] update inline documentation
- [x] update default build systems definitions
- [x] provide `:Build init`
- [x] update doc/build.txt
- [x] update README.md
- [x] test different build systems

Bonus:
- [x] provide `:Build info`
- [x] add internal `:Build help`
- [x] provide a `:Build test`